### PR TITLE
Make the eye dropper work with more than one screen

### DIFF
--- a/src/WpfColorPicker/EyeDropper.xaml.cs
+++ b/src/WpfColorPicker/EyeDropper.xaml.cs
@@ -4,6 +4,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using WpfScreenHelper;
 using Color = System.Windows.Media.Color;
 
 namespace Dsafa.WpfColorPicker
@@ -26,9 +27,9 @@ namespace Dsafa.WpfColorPicker
             set => SetValue(SelectedColorProperty, value);
         }
 
-        public static Rectangle CurrentScreenRect()
+        public static Rect CurrentScreenRect()
         {
-            return System.Windows.Forms.Screen.FromPoint(System.Windows.Forms.Cursor.Position).Bounds;
+            return Screen.FromPoint(MouseHelper.MousePosition).Bounds;
         }
 
         private void ButtonOnClick(object sender, RoutedEventArgs e)
@@ -40,11 +41,11 @@ namespace Dsafa.WpfColorPicker
             {
                 // Changing the screen rect and image unfortunately causes a short flash of the old
                 // image on the new screen. To circumvent this issue, we first set the window to be
-                // invisible (with a size of 0x0.
+                // invisible (with a size of 0x0).
                 // This is not ideal but makes the issue less noticable. Actually hiding the window
                 // seems to work better but we can't do that because calling `.Hide()` or setting
                 // `.Visibility` sets the `DialogResult` to `false`.
-                window.SetScreenRect(new Rectangle(0, 0, 0, 0));
+                window.SetScreenRect(new Rect(0, 0, 0, 0));
                 window.SetImage(ScreenshotBitmapImage());
                 window.SetScreenRect(CurrentScreenRect());
             };
@@ -79,11 +80,11 @@ namespace Dsafa.WpfColorPicker
 
         private Bitmap TakeScreenshot()
         {
-            Rectangle screen = CurrentScreenRect();
-            var screenBitmap = new Bitmap(screen.Width, screen.Height, System.Drawing.Imaging.PixelFormat.Format32bppPArgb);
+            Rect screen = CurrentScreenRect();
+            var screenBitmap = new Bitmap((int)screen.Width, (int)screen.Height, System.Drawing.Imaging.PixelFormat.Format32bppPArgb);
             using (var g = Graphics.FromImage(screenBitmap))
             {
-                g.CopyFromScreen(screen.Left, screen.Top, 0, 0, screenBitmap.Size);
+                g.CopyFromScreen((int)screen.Left, (int)screen.Top, 0, 0, screenBitmap.Size);
             }
 
             return screenBitmap;

--- a/src/WpfColorPicker/EyeDropper.xaml.cs
+++ b/src/WpfColorPicker/EyeDropper.xaml.cs
@@ -26,7 +26,37 @@ namespace Dsafa.WpfColorPicker
             set => SetValue(SelectedColorProperty, value);
         }
 
+        public static Rectangle CurrentScreenRect()
+        {
+            return System.Windows.Forms.Screen.FromPoint(System.Windows.Forms.Cursor.Position).Bounds;
+        }
+
         private void ButtonOnClick(object sender, RoutedEventArgs e)
+        {
+            var window = new EyeDropperWindow(ScreenshotBitmapImage());
+            // The EyeDropperWindow spans the entire current screen, so this event gets called whenever
+            // the mouse changes from one screen to another.
+            window.MouseLeave += (_s, _e) =>
+            {
+                // Changing the screen rect and image unfortunately causes a short flash of the old
+                // image on the new screen. To circumvent this issue, we first set the window to be
+                // invisible (with a size of 0x0.
+                // This is not ideal but makes the issue less noticable. Actually hiding the window
+                // seems to work better but we can't do that because calling `.Hide()` or setting
+                // `.Visibility` sets the `DialogResult` to `false`.
+                window.SetScreenRect(new Rectangle(0, 0, 0, 0));
+                window.SetImage(ScreenshotBitmapImage());
+                window.SetScreenRect(CurrentScreenRect());
+            };
+            window.SetScreenRect(CurrentScreenRect());
+            var res = window.ShowDialog();
+            if (res.HasValue && res.Value)
+            {
+                SelectedColor = window.SelectedColor;
+            }
+        }
+
+        private BitmapImage ScreenshotBitmapImage()
         {
             var screenshot = TakeScreenshot();
 
@@ -44,20 +74,16 @@ namespace Dsafa.WpfColorPicker
 
             screenshot.Dispose();
 
-            var window = new EyeDropperWindow(bitmapImage);
-            var res = window.ShowDialog();
-            if (res.HasValue && res.Value)
-            {
-                SelectedColor = window.SelectedColor;
-            }
+            return bitmapImage;
         }
 
         private Bitmap TakeScreenshot()
         {
-            var screenBitmap = new Bitmap((int)SystemParameters.PrimaryScreenWidth, (int)SystemParameters.PrimaryScreenHeight, System.Drawing.Imaging.PixelFormat.Format32bppPArgb);
+            Rectangle screen = CurrentScreenRect();
+            var screenBitmap = new Bitmap(screen.Width, screen.Height, System.Drawing.Imaging.PixelFormat.Format32bppPArgb);
             using (var g = Graphics.FromImage(screenBitmap))
             {
-                g.CopyFromScreen(0, 0, 0, 0, screenBitmap.Size);
+                g.CopyFromScreen(screen.Left, screen.Top, 0, 0, screenBitmap.Size);
             }
 
             return screenBitmap;

--- a/src/WpfColorPicker/EyeDropperWindow.xaml
+++ b/src/WpfColorPicker/EyeDropperWindow.xaml
@@ -8,7 +8,7 @@
         mc:Ignorable="d"
         Title="EyeDropperWindow"
         ResizeMode="NoResize"
-        WindowState="Maximized" WindowStyle="None"
+        WindowStyle="None"
         KeyDown="WindowOnKeyDown"
         Loaded="WindowOnLoaded"
         MouseDown="WindowOnMouseDown">

--- a/src/WpfColorPicker/EyeDropperWindow.xaml.cs
+++ b/src/WpfColorPicker/EyeDropperWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace Dsafa.WpfColorPicker
 
         public Color SelectedColor { get; private set; }
 
-        public void SetScreenRect(System.Drawing.Rectangle screenRect)
+        public void SetScreenRect(Rect screenRect)
         {
             // Apparently, the window cannot be maximized when we want to move it to a different screen.
             // Thanks to: http://www.codewrecks.com/blog/index.php/2013/01/05/open-a-window-in-fullscreen-on-a-specific-monitor-in-wpf/

--- a/src/WpfColorPicker/EyeDropperWindow.xaml.cs
+++ b/src/WpfColorPicker/EyeDropperWindow.xaml.cs
@@ -13,17 +13,33 @@ namespace Dsafa.WpfColorPicker
     internal partial class EyeDropperWindow : Window
     {
         private readonly EyeDropperWindowAdorner _adorner;
-        private readonly BitmapImage _image;
+        private BitmapImage _image;
 
         public EyeDropperWindow(BitmapImage image)
         {
             InitializeComponent();
-            windowImage.Source = image;
-            _image = image;
+            SetImage(image);
             _adorner = new EyeDropperWindowAdorner(windowImage);
         }
 
         public Color SelectedColor { get; private set; }
+
+        public void SetScreenRect(System.Drawing.Rectangle screenRect)
+        {
+            // Apparently, the window cannot be maximized when we want to move it to a different screen.
+            // Thanks to: http://www.codewrecks.com/blog/index.php/2013/01/05/open-a-window-in-fullscreen-on-a-specific-monitor-in-wpf/
+            WindowState = WindowState.Normal;
+            Left = screenRect.Left;
+            Top = screenRect.Top;
+            Width = screenRect.Width;
+            Height = screenRect.Height;
+        }
+
+        public void SetImage(BitmapImage image)
+        {
+            windowImage.Source = image;
+            _image = image;
+        }
 
         protected override void OnMouseMove(MouseEventArgs e)
         {

--- a/src/WpfColorPicker/WpfColorPicker.csproj
+++ b/src/WpfColorPicker/WpfColorPicker.csproj
@@ -43,6 +43,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>

--- a/src/WpfColorPicker/WpfColorPicker.csproj
+++ b/src/WpfColorPicker/WpfColorPicker.csproj
@@ -43,13 +43,15 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
+    <Reference Include="WpfScreenHelper, Version=0.3.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\WpfScreenHelper.0.3.0.0\lib\net40\WpfScreenHelper.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ColorHelper.cs" />
@@ -104,6 +106,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/src/WpfColorPicker/packages.config
+++ b/src/WpfColorPicker/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="WpfScreenHelper" version="0.3.0.0" targetFramework="net462" />
+</packages>


### PR DESCRIPTION
Hi,

first of all, thank you very much for the great library! It was very helpful for a [recent project of mine](https://github.com/baltpeter/contrastor-windows). 

I noticed that the eye dropper was hardcoded to only use the primary
screen.

In this PR, I tried to change that behaviour to essentially use the screen
the mouse is located on instead and re-take the screenshot as well as move
the eye dropper window when the mouse moves to a different screen.

Unfortunately, this change depends on winforms code for the `System.Windows.Forms.Screen` API. It may be possible to instead replace that with [WpfScreenHelper](https://github.com/micdenny/WpfScreenHelper) which seems to be a little more lightweight. Not sure what your preferences are here.

Let me know if you need any more changes to be done.

Cheers,
Benni